### PR TITLE
CentOS builds are broken

### DIFF
--- a/src/centos.sh
+++ b/src/centos.sh
@@ -20,7 +20,7 @@
 #
 function build() {
     local centos_release
-    if [[ -f /config/centos-release ]]
+    if [[ -f /config/centos-release ]]; then
         centos_release=$(cat /config/centos-release)
     else
         centos_release=$(nsenter -t 1 -m cat /etc/centos-release)


### PR DESCRIPTION
## Issues Addressed

Fixes #11

## Proposed Changes

Apparently I introduced a bug late in development and forgot to re-test. Simply missed a "; then" clause.

## Testing

Built CentOS binaries using the zfs-releases repository.
