### PR TITLE
Retry apt-get on network failure or timeout

### DIFF
--- a/src/ubuntu.sh
+++ b/src/ubuntu.sh
@@ -4,12 +4,34 @@
 #
 
 #
+# apt-get can hang on poor network connections. This will enforce a reasonble
+# timeout and retry the download if it takes too long.
+#
+function safe_apt_get() {
+    local retry=3 count=0
+
+    while true; do
+        if timeout 60 apt-get install --download-only -y --fix-missing $*; then
+            break
+        fi
+        if (( count++ == retry )); then
+            printf 'Download $* failed\n' >&2
+            exit 1
+        fi
+    done
+
+    apt-get install -y $*
+}
+
+#
 # Get ubuntu-specific modules. With Ubuntu, we can get the pre-built modules and
 # headers for a given kernel release, so that we don't need to actually build from source.
 #
 function get_kernel() {
     apt-get update
-    apt-get install -y linux-modules-$KERNEL_RELEASE linux-headers-$KERNEL_RELEASE linux-source-$KERNEL_VERSION
+    safe_apt_get linux-modules-$KERNEL_RELEASE
+    safe_apt_get linux-headers-$KERNEL_RELEASE
+    safe_apt_get linux-source-$KERNEL_VERSION
     cd /usr/src && tar -xjf linux-source-$KERNEL_VERSION.tar.bz2
 
     KERNEL_SRC=/usr/src/linux-source-$KERNEL_VERSION


### PR DESCRIPTION
## Issues Addressed

Fixes #13

## Proposed Changes

I'm still not totally sure why apt-get hangs like it does, but it's pretty reproducible on Travis, and searching the internet shows it's not an isolated problem. Adding a timeout/retry loop provides extra insurance against this behavior.

## Testing

Ran ubuntu builds and verified that packages were downloaded properly