### PR TITLE
add support for specifying CentOS vault configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ supports the following operating systems:
              later, may or may not work with other releases.
   * CentOS - Requires access to the docker socket, and either (a) privileged
              host access or (b) `/config/centos-release` from
-             `/etc/centos-release`. Tested with CentOS 7, may or may not work
-             with other releases.
+             `/etc/centos-release`. You may need to add yum repo configuration
+             in `/config/centos-vault` to access the right CentOS vault to
+             find the appropriate packages, if it's an older kernel. Tested
+             with CentOS 7, may or may not work with other releases.
   * Vanilla - Requires either (a) `/proc/config.gz` to be present, or
               `/config/config.gz` to be present with the kernel configuration.
               Optionally can specify the kernel source with `-v path:/src/linux`,


### PR DESCRIPTION
## Proposed Changes

CentOS is pretty aggressive about moving older kernels into their "vault", so we can't just expect to find older kernels in the latest locations. Rather than making zfs-builder aware of all known vault locations, this changes allows the caller to specify alternative contents for `/etc/yum.repos.d/CentOS-Vault.repo` by creating a file called `centos-vault` in the config directory.

## Testing

Built our CentOS ZFS binaries in `zfs-releases` that were previously failing.