### PR TITLE
add support for WSL2 kernels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,14 @@ RUN apt-get install -y                                                       \
 # Linuxkit binaries (such as fixdep) require musl
 RUN apt-get install -y musl
 
-# Linuxkit requires the ability to copy data from docker images
+# Tar can fail sometimes on overlayfs, use bsdtar as a workaround
+RUN apt-get install -y bsdtar
+
+# Add required tools for those distros that require building the kernel from source
+RUN apt-get install -y build-essential libncurses-dev bison flex libssl-dev   \
+    libelf-dev
+
+# Some distros require the ability to copy data from docker images
 RUN apt-get -y install apt-transport-https \
      ca-certificates \
      curl \

--- a/src/build.sh
+++ b/src/build.sh
@@ -19,6 +19,9 @@ function get_kernel_type() {
     linuxkit)
         echo linuxkit
         ;;
+    microsoft-standard)
+        echo wsl
+        ;;
     *)
         case $KERNEL_UNAME in
         *Ubuntu*)

--- a/src/wsl.sh
+++ b/src/wsl.sh
@@ -3,17 +3,29 @@
 # Copyright The Titan Project Contributors.
 #
 
+#
+# Build process for the WSL2 (Windows Service for Linux 2) kernel. The kernel is
+# available at:
+#
+# https://github.com/microsoft/WSL2-Linux-Kernel
+#
+# However, there do not appear to be any pre-built binary packages, so we need
+# to fetch the kernel source and build it ourselves. Like the vanilla kernel
+# build process, we need a config.gz file to make sure we're building with the
+# appropriate kernel parameters.
+#
+
 # Get vanilla kernel source
 function get_kernel_src() {
     local version=$KERNEL_VERSION
 
     # Download Kernel source
     if [ ! -d /src/linux ]; then
-        curl --retry 5 -o /src/linux-$version.tar.xz -L https://www.kernel.org/pub/linux/kernel/v${version%%.*}.x/linux-$version.tar.xz
+        curl --retry 5 -o /src/$KERNEL_RELEASE.tar.gz -L https://github.com/microsoft/WSL2-Linux-Kernel/archive/$KERNEL_RELEASE.tar.gz
         cd /src
-        bsdtar xf linux-$version.tar.xz
-        mv linux-$version linux
-        rm linux-$version.tar.xz
+        bsdtar xf $KERNEL_RELEASE.tar.gz
+        mv WSL2-Linux-Kernel-$KERNEL_RELEASE linux
+        rm $KERNEL_RELEASE.tar.gz
     fi
 
     KERNEL_SRC=/src/linux


### PR DESCRIPTION
## Proposed Changes

WSL2 (Windows Services for Linux 2) is in the latest Kernel edge builds, and there is a Docker Tech Preview available that makes use of it. This adds support for building these kernels. The underlying kernel is a custom one, found here:

https://github.com/microsoft/WSL2-Linux-Kernel

There does not appear to be any way to download pre-built kernel headers and binaries, so we build the kernel from source and then build ZFS to match.

## Testing

Built 4.19.72-microsoft-standard (latest WSL2 kernel)