### PR TITLE
Fixes for linuxkit 4.14.134

### DIFF
--- a/src/linuxkit.sh
+++ b/src/linuxkit.sh
@@ -18,10 +18,21 @@ function get_kernel() {
     docker cp $container_name:kernel.tar .
     bsdtar xf kernel-dev.tar
     bsdtar xf kernel.tar
+    rm kernel-dev.tar kernel.tar
 
     cd /src
     docker cp $container_name:linux.tar.xz .
     bsdtar xf linux.tar.xz
+    rm linux.tar.xz
+
+    #
+    # Some versions of linuxkit apparently leave the built gcc plugins in the
+    # kernel tree, which can then generate errors because it's looking for
+    # symbols or libraries that might not exist on this system. Build works
+    # fine without them, so blow them away if they happen to be there.
+    #
+    rm -f /usr/src/*/scripts/gcc-plugins/*.so
+    rm -f /usr/src/*/scripts/gcc-plugins/*.o
 
     docker rm $container_name
 

--- a/src/linuxkit.sh
+++ b/src/linuxkit.sh
@@ -16,12 +16,12 @@ function get_kernel() {
     cd /
     docker cp $container_name:kernel-dev.tar .
     docker cp $container_name:kernel.tar .
-    tar xf kernel-dev.tar
-    tar xf kernel.tar
+    bsdtar xf kernel-dev.tar
+    bsdtar xf kernel.tar
 
     cd /src
     docker cp $container_name:linux.tar.xz .
-    tar xf linux.tar.xz
+    bsdtar xf linux.tar.xz
 
     docker rm $container_name
 


### PR DESCRIPTION
## Proposed Changes

Stock tar can have issues with overlayfs on MacOS. A previous push added 'bsdtar' and updated some of the distros to use it, but neglected linuxkit. This updates linuxkit to use the same workaround.

In addition, when testing with linuxkit 4.14.134, I found that their build can leave around incompatible gcc plugins. We need to remove these prior to attempting a build (as older versions did).

## Testing

Built 4.14.131-linuxkit
