### PR TITLE
Fix for CentOS ZFS Builds

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -27,7 +27,7 @@ function get_kernel_type() {
         *Ubuntu*)
             echo ubuntu
             ;;
-        *.el[0-9].*)
+        *.el[0-9]_[0-9].*)
             echo centos
             ;;
         *)

--- a/src/build.sh
+++ b/src/build.sh
@@ -27,8 +27,11 @@ function get_kernel_type() {
         *Ubuntu*)
             echo ubuntu
             ;;
-        *.el[0-9]_[0-9].*)
+        *.el[0-9].*)
             echo centos
+            ;;
+        *.el8_[0-9].*)
+	    echo centos8x
             ;;
         *)
             echo vanilla

--- a/src/centos.sh
+++ b/src/centos.sh
@@ -55,6 +55,8 @@ function build() {
     fi
     cat > /docker/Dockerfile <<EOF
 FROM centos:centos$centos_version
+RUN yum install dnf-plugins-core
+RUN yum config-manager --set-enabled PowerTools
 RUN yum install -y gcc git
 RUN yum install -y autoconf automake libtool make rpm-build ksh
 RUN yum install -y zlib-devel libuuid-devel libattr-devel libblkid-devel libselinux-devel libudev-devel

--- a/src/centos.sh
+++ b/src/centos.sh
@@ -55,7 +55,7 @@ function build() {
     fi
     cat > /docker/Dockerfile <<EOF
 FROM centos:centos$centos_version
-RUN yum install dnf-plugins-core
+RUN yum install -y dnf-plugins-core
 RUN yum config-manager --set-enabled PowerTools
 RUN yum install -y gcc git
 RUN yum install -y autoconf automake libtool make rpm-build ksh

--- a/src/centos8x.sh
+++ b/src/centos8x.sh
@@ -55,6 +55,8 @@ function build() {
     fi
     cat > /docker/Dockerfile <<EOF
 FROM centos:centos$centos_version
+RUN yum install -y dnf-plugins-core
+RUN yum config-manager --set-enabled PowerTools
 RUN yum install -y gcc git
 RUN yum install -y autoconf automake libtool make rpm-build ksh
 RUN yum install -y zlib-devel libuuid-devel libattr-devel libblkid-devel libselinux-devel libudev-devel


### PR DESCRIPTION
## Issues Addressed

CentOS was not working

## Proposed Changes

Made sure it was picking up that we were in CentOS land (gonna tackle RHEL next). Very simple change to the RegEx.

Also, device-mapper-devel package is in the Power Tools repos in CentOS, so had to enable that repos.

## Testing

Tested using the ./build 4.18.0-147.5.1.el8_1.x86_64 in zfs-releases.
